### PR TITLE
Fix panel layout overflow

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -59,6 +59,7 @@
       transform: translateX(100%);
       transition: transform 0.25s ease;
       pointer-events: none;
+      overflow: hidden;
     }
 
     .panel.open {
@@ -91,6 +92,7 @@
 
     .content {
       flex: 1;
+      min-height: 0;
       overflow: hidden;
       padding: 12px 16px;
       display: flex;
@@ -107,6 +109,7 @@
       flex-direction: column;
       gap: 8px;
       flex: 1;
+      min-height: 0;
     }
 
     .section h2 {


### PR DESCRIPTION
## Summary
- prevent the assistant panel from overflowing the viewport
- allow the chat log to scroll while keeping the input visible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5ae111344832cbd85bcd90f7d106a