### PR TITLE
Switch extension to CopilotKit agent backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Permit AI Helper is a browser extension for Chromium-based browsers that adds an
 - **Form discovery** – Automatically detects inputs, textareas, and selects. Each field shows quick actions to focus, request guidance, or improve the existing answer.
 - **On-page editing** – Accepted improvements are written back into the form and trigger standard `input`/`change` events for compatibility with validation scripts.
 - **Context-aware prompts** – Sends the page URL, title, and recent field metadata to the AI model so responses stay relevant to the current task.
-- **OpenAI integration** – Uses the Chat Completions API (default model: `gpt-4o-mini`). The API key is stored locally via Chrome sync storage and never leaves the browser except for OpenAI requests.
+- **CopilotKit integration** – Sends every request through CopilotKit so you can use Copilot Cloud or your own CopilotKit deployment. Credentials are stored locally via Chrome sync storage.
 
 ## Getting started
 
@@ -16,7 +16,8 @@ Permit AI Helper is a browser extension for Chromium-based browsers that adds an
 2. Open `chrome://extensions` (or the equivalent page in your Chromium browser).
 3. Enable **Developer mode**.
 4. Choose **Load unpacked** and select the repository folder.
-5. Open the extension **Options** page and add your OpenAI API key.
+5. Open the extension **Options** page and add your Copilot Cloud public API key (and optional custom endpoint).
+   - Leave the endpoint blank to use `https://api.cloud.copilotkit.ai/copilotkit`.
 
 After loading, a “Permit AI” tab appears on the right edge of every page. Click it to open the assistant.
 
@@ -25,18 +26,18 @@ After loading, a “Permit AI” tab appears on the right edge of every page. Cl
 - All source files are plain JavaScript/HTML/CSS—no build step required.
 - Background logic lives in [`background.js`](background.js) and communicates with the content script via `chrome.runtime.sendMessage`.
 - The sidebar UI is injected by [`contentScript.js`](contentScript.js) using a shadow DOM to avoid style conflicts with the host page.
-- User settings (currently just the OpenAI API key) are managed through [`options.html`](options.html) and [`options.js`](options.js).
+- User settings (Copilot Cloud key and optional endpoint) are managed through [`options.html`](options.html) and [`options.js`](options.js).
 
 ### Testing tips
 
 - Use Chrome’s **Extensions** page to inspect the background service worker for logs.
 - When validating form autofill, open DevTools on the target page and watch for `input`/`change` events.
-- If the assistant reports missing credentials, revisit the options page and confirm the API key is saved.
+- If the assistant reports missing credentials, revisit the options page and confirm the CopilotKit settings are saved.
 
 ## Security & privacy considerations
 
 - The extension requests `<all_urls>` host permissions so it can read forms on any page where the assistant is opened.
-- API keys are stored with `chrome.storage.sync`; remove the key from the options page if you no longer want the extension to access OpenAI.
+- Copilot credentials are stored with `chrome.storage.sync`; remove the key from the options page if you no longer want the extension to access CopilotKit.
 - Only detected form metadata and the text you send are included in prompts. Sensitive data should be reviewed before submission.
 
 ## License

--- a/background.js
+++ b/background.js
@@ -1,4 +1,38 @@
-const MODEL = 'gpt-4o-mini';
+const DEFAULT_COPILOTKIT_ENDPOINT = 'https://api.cloud.copilotkit.ai/copilotkit';
+const COPILOTKIT_MUTATION = `
+  mutation GenerateCopilotResponse($input: GenerateCopilotResponseInput!) {
+    generateCopilotResponse(data: $input) {
+      messages {
+        __typename
+        ... on TextMessageOutput {
+          id
+          role
+          content
+        }
+        ... on ActionExecutionMessageOutput {
+          id
+          name
+          arguments
+        }
+        ... on ResultMessageOutput {
+          id
+          actionName
+          result
+        }
+      }
+      status {
+        __typename
+        code
+        ... on FailedResponseStatus {
+          reason
+          details
+        }
+      }
+      threadId
+      runId
+    }
+  }
+`;
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message?.type === 'callAI') {
@@ -14,11 +48,19 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 });
 
 async function handleCallAi(payload = {}) {
-  const apiKeyRecord = await chrome.storage.sync.get('permitAiApiKey');
-  const apiKey = apiKeyRecord?.permitAiApiKey?.trim();
+  const settingsRecord = await chrome.storage.sync.get('copilotkitSettings');
+  const apiKey = settingsRecord?.copilotkitSettings?.apiKey?.trim();
+  const endpoint = settingsRecord?.copilotkitSettings?.endpoint?.trim() || DEFAULT_COPILOTKIT_ENDPOINT;
+
   if (!apiKey) {
     return {
-      error: 'Add your OpenAI API key in the Permit AI Helper options page before using the assistant.'
+      error: 'Add your Copilot Cloud public API key in the Permit AI Helper options page before using the assistant.'
+    };
+  }
+
+  if (!endpoint) {
+    return {
+      error: 'Set a valid CopilotKit endpoint URL in the options page.'
     };
   }
 
@@ -27,83 +69,173 @@ async function handleCallAi(payload = {}) {
     ? messages.slice(-12).map(mapMessage)
     : [];
 
-  const contextMessage = buildContextMessage(context);
-  if (contextMessage) {
-    sanitizedMessages.push(contextMessage);
+  if (!sanitizedMessages.length) {
+    return { error: 'No conversation context was provided to CopilotKit.' };
+  }
+
+  const frontend = { actions: [] };
+  if (context && typeof context.url === 'string' && context.url) {
+    frontend.url = context.url;
+  }
+
+  const graphInput = {
+    metadata: { requestType: 'Chat' },
+    messages: sanitizedMessages,
+    frontend
+  };
+
+  const contextEntries = buildContextEntries(context);
+  if (contextEntries.length) {
+    graphInput.context = contextEntries;
   }
 
   try {
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    const response = await fetch(endpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${apiKey}`
+        Accept: 'application/json',
+        'X-CopilotCloud-Public-API-Key': apiKey
       },
       body: JSON.stringify({
-        model: MODEL,
-        temperature: 0.2,
-        messages: sanitizedMessages
+        query: COPILOTKIT_MUTATION,
+        variables: { input: graphInput }
       })
     });
 
     if (!response.ok) {
       const errorText = await response.text();
-      console.error('[Permit AI Helper] API error', errorText);
-      return { error: 'The AI service returned an error. Check the console for details.' };
+      console.error('[Permit AI Helper] CopilotKit API error', errorText);
+      return { error: 'The CopilotKit service returned an error. Check the console for details.' };
     }
 
     const data = await response.json();
-    const message = data?.choices?.[0]?.message?.content;
+    if (Array.isArray(data?.errors) && data.errors.length) {
+      console.error('[Permit AI Helper] CopilotKit GraphQL errors', data.errors);
+      return { error: data.errors[0]?.message || 'CopilotKit reported an error while processing the request.' };
+    }
+
+    const runtimeResponse = data?.data?.generateCopilotResponse;
+    if (!runtimeResponse) {
+      return { error: 'Received an unexpected response from CopilotKit.' };
+    }
+
+    const status = runtimeResponse.status;
+    if (status?.__typename === 'FailedResponseStatus') {
+      const reason = status?.reason || 'CopilotKit request failed.';
+      console.error('[Permit AI Helper] CopilotKit reported failure', status);
+      return { error: reason };
+    }
+
+    const message = extractAssistantMessage(runtimeResponse.messages);
+    if (!message) {
+      return { error: 'CopilotKit did not return any assistant message.' };
+    }
+
     return { message };
   } catch (error) {
-    console.error('[Permit AI Helper] Failed to reach OpenAI', error);
-    return { error: 'Could not reach the AI service. Verify your internet connection.' };
+    console.error('[Permit AI Helper] Failed to reach CopilotKit', error);
+    return { error: 'Could not reach the CopilotKit service. Verify your endpoint and network connection.' };
   }
 }
 
-function mapMessage(msg) {
+function mapMessage(msg, index, allMessages) {
   if (!msg || typeof msg !== 'object') {
-    return { role: 'user', content: String(msg) };
+    return buildTextMessage('user', String(msg), index, allMessages.length);
   }
-  const role = ['system', 'user', 'assistant'].includes(msg.role) ? msg.role : 'user';
+
+  const allowedRoles = ['system', 'user', 'assistant', 'developer'];
+  const role = allowedRoles.includes(msg.role) ? msg.role : 'user';
+  const content = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content);
+
+  return buildTextMessage(role, content, index, allMessages.length);
+}
+
+function buildTextMessage(role, content, index, total) {
+  const offsetMs = (total - index) * 1000;
+  const createdAt = new Date(Date.now() - offsetMs).toISOString();
   return {
-    role,
-    content: typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content)
+    id: typeof crypto?.randomUUID === 'function' ? crypto.randomUUID() : `${Date.now()}-${index}`,
+    createdAt,
+    textMessage: {
+      role,
+      content
+    }
   };
 }
 
-function buildContextMessage(context) {
-  if (!context || typeof context !== 'object') return null;
-  const snippets = [];
+function buildContextEntries(context) {
+  if (!context || typeof context !== 'object') return [];
+  const entries = [];
+
   if (context.url) {
-    snippets.push(`Current URL: ${context.url}`);
+    entries.push({ description: 'Current URL', value: String(context.url) });
   }
+
   if (context.title) {
-    snippets.push(`Page title: ${context.title}`);
+    entries.push({ description: 'Page title', value: String(context.title) });
   }
+
   if (Array.isArray(context.fields) && context.fields.length) {
-    const fieldDescriptions = context.fields
-      .slice(0, 10)
-      .map((field, index) => {
-        const label = field?.label || field?.name || field?.placeholder || field?.tagName || `Field ${index + 1}`;
-        const value = field?.value ? `Value: ${field.value}` : 'Value: (empty)';
-        const id = field?.id ? `ID: ${field.id}` : field?.name ? `Name: ${field.name}` : null;
-        const idSuffix = id ? ` • ${id}` : '';
-        return `• ${label} (${field?.tagName || 'input'}${idSuffix}): ${value}`;
-      })
-      .join('\n');
-    snippets.push('Visible form fields:\n' + fieldDescriptions);
+    const fieldDescriptions = context.fields.slice(0, 10).map((field, index) => {
+      const label = field?.label || field?.name || field?.placeholder || field?.tagName || `Field ${index + 1}`;
+      const id = field?.id || field?.name || '';
+      const value = field?.value ? String(field.value) : '(empty)';
+      const identifier = id ? ` • ${id}` : '';
+      return `• ${label}${identifier}: ${value}`;
+    });
+
+    entries.push({
+      description: 'Visible form fields',
+      value: fieldDescriptions.join('\n')
+    });
   }
+
   if (context.field) {
     const field = context.field;
-    snippets.push(`Active field label: ${field.label || field.name || field.placeholder || field.tagName}`);
-    if (field.id) snippets.push(`Active field ID: ${field.id}`);
-    if (field.placeholder) snippets.push(`Field placeholder: ${field.placeholder}`);
-    if (field.value) snippets.push(`Current value: ${field.value}`);
+    const details = [];
+    if (field.label || field.name || field.placeholder || field.tagName) {
+      details.push(`Label: ${field.label || field.name || field.placeholder || field.tagName}`);
+    }
+    if (field.id) details.push(`ID: ${field.id}`);
+    if (field.placeholder) details.push(`Placeholder: ${field.placeholder}`);
+    if (field.value) details.push(`Current value: ${field.value}`);
+
+    if (details.length) {
+      entries.push({
+        description: 'Active field details',
+        value: details.join('\n')
+      });
+    }
   }
-  if (!snippets.length) return null;
-  return {
-    role: 'system',
-    content: `Additional page context for this conversation:\n${snippets.join('\n')}`
-  };
+
+  return entries;
+}
+
+function extractAssistantMessage(messages) {
+  if (!Array.isArray(messages)) return '';
+
+  const assistantTexts = [];
+  const actionBlocks = [];
+
+  for (const message of messages) {
+    if (!message || typeof message !== 'object') continue;
+    if (message.__typename === 'TextMessageOutput' && message.role === 'assistant') {
+      const content = Array.isArray(message.content) ? message.content.join('') : message.content;
+      if (content) {
+        assistantTexts.push(String(content).trim());
+      }
+    } else if (message.__typename === 'ActionExecutionMessageOutput' && Array.isArray(message.arguments)) {
+      const serialized = message.arguments
+        .map(arg => (typeof arg === 'string' ? arg.trim() : JSON.stringify(arg)))
+        .filter(Boolean)
+        .join('\n');
+      if (serialized) {
+        actionBlocks.push(['```action', serialized, '```'].join('\n'));
+      }
+    }
+  }
+
+  const combined = [...assistantTexts, ...actionBlocks].filter(Boolean).join('\n\n').trim();
+  return combined;
 }

--- a/contentScript.js
+++ b/contentScript.js
@@ -692,7 +692,7 @@
       });
 
       if (!response || response.error) {
-        const message = response && response.error ? response.error : 'Unable to reach Permit AI service. Check your API key in extension options.';
+        const message = response && response.error ? response.error : 'Unable to reach Permit AI service. Check your CopilotKit settings in extension options.';
         recordMessage('assistant', message);
         return message;
       }

--- a/options.css
+++ b/options.css
@@ -46,12 +46,17 @@ label {
   font-weight: 600;
 }
 
-input[type='password'] {
+input[type='password'],
+input[type='url'] {
   padding: 10px 12px;
   font-size: 14px;
   border-radius: 8px;
   border: 1px solid rgba(15, 23, 42, 0.25);
   font-family: inherit;
+}
+
+label + input {
+  margin-top: -4px;
 }
 
 .actions {

--- a/options.html
+++ b/options.html
@@ -9,16 +9,38 @@
     <main>
       <h1>Permit AI Helper</h1>
       <p>
-        Enter your OpenAI API key to enable the assistant. The key is stored locally using
-        Chrome sync storage and is only used to call the OpenAI Chat Completions API.
+        Permit AI Helper now talks to <strong>CopilotKit</strong>. Provide your Copilot Cloud public API key and (optionally) a
+        custom endpoint URL to activate the assistant. Credentials are stored locally via Chrome sync storage and only used for
+        CopilotKit requests.
       </p>
       <form id="options-form">
-        <label for="api-key">OpenAI API key</label>
-        <input id="api-key" name="api-key" type="password" autocomplete="off" placeholder="sk-..." required />
-        <p class="hint">Generate a key at <a href="https://platform.openai.com/account/api-keys" target="_blank" rel="noreferrer">platform.openai.com</a>.</p>
+        <label for="api-key">Copilot Cloud public API key</label>
+        <input
+          id="api-key"
+          name="api-key"
+          type="password"
+          autocomplete="off"
+          placeholder="ckpk-..."
+          required
+        />
+        <p class="hint">
+          Create or view keys in
+          <a href="https://cloud.copilotkit.ai" target="_blank" rel="noreferrer">Copilot Cloud</a>.
+        </p>
+        <label for="endpoint">CopilotKit endpoint (optional)</label>
+        <input
+          id="endpoint"
+          name="endpoint"
+          type="url"
+          autocomplete="off"
+          placeholder="https://api.cloud.copilotkit.ai/copilotkit"
+        />
+        <p class="hint">
+          Leave blank to use the default Copilot Cloud endpoint. Provide your own URL if you host CopilotKit yourself.
+        </p>
         <div class="actions">
           <button type="submit">Save</button>
-          <button type="button" id="clear">Remove key</button>
+          <button type="button" id="clear">Remove credentials</button>
         </div>
       </form>
       <output id="status" role="status" aria-live="polite"></output>
@@ -26,7 +48,7 @@
         <h2>How it works</h2>
         <ul>
           <li>The assistant can summarize form fields and draft polished responses.</li>
-          <li>No data is stored outside of your browser besides requests sent to OpenAI.</li>
+          <li>No data is stored outside of your browser besides requests sent to CopilotKit.</li>
           <li>You can close the sidebar at any time using the × button at the top.</li>
         </ul>
       </section>

--- a/options.js
+++ b/options.js
@@ -1,5 +1,6 @@
 const form = document.getElementById('options-form');
-const input = document.getElementById('api-key');
+const apiKeyInput = document.getElementById('api-key');
+const endpointInput = document.getElementById('endpoint');
 const clearButton = document.getElementById('clear');
 const status = document.getElementById('status');
 
@@ -7,40 +8,51 @@ init();
 
 async function init() {
   try {
-    const stored = await chrome.storage.sync.get('permitAiApiKey');
-    if (stored?.permitAiApiKey) {
-      input.value = stored.permitAiApiKey;
+    const stored = await chrome.storage.sync.get('copilotkitSettings');
+    const settings = stored?.copilotkitSettings;
+    if (settings?.apiKey) {
+      apiKeyInput.value = settings.apiKey;
+    }
+    if (settings?.endpoint) {
+      endpointInput.value = settings.endpoint;
     }
   } catch (error) {
-    console.error('[Permit AI Helper] Failed to read API key', error);
-    renderStatus('Unable to load stored key.', true);
+    console.error('[Permit AI Helper] Failed to read CopilotKit settings', error);
+    renderStatus('Unable to load stored CopilotKit settings.', true);
   }
 }
 
 form.addEventListener('submit', async (event) => {
   event.preventDefault();
-  const value = input.value.trim();
-  if (!value) {
-    renderStatus('Enter a valid API key.', true);
+  const apiKey = apiKeyInput.value.trim();
+  const endpoint = endpointInput.value.trim();
+
+  if (!apiKey) {
+    renderStatus('Enter a valid Copilot Cloud API key.', true);
     return;
   }
   try {
-    await chrome.storage.sync.set({ permitAiApiKey: value });
-    renderStatus('API key saved. You can close this tab.', false);
+    const settings = {
+      apiKey,
+      endpoint: endpoint || undefined
+    };
+    await chrome.storage.sync.set({ copilotkitSettings: settings });
+    renderStatus('CopilotKit settings saved. You can close this tab.', false);
   } catch (error) {
-    console.error('[Permit AI Helper] Failed to store API key', error);
-    renderStatus('Failed to store the key. Try again.', true);
+    console.error('[Permit AI Helper] Failed to store CopilotKit settings', error);
+    renderStatus('Failed to store the settings. Try again.', true);
   }
 });
 
 clearButton.addEventListener('click', async () => {
   try {
-    await chrome.storage.sync.remove('permitAiApiKey');
-    input.value = '';
-    renderStatus('API key removed.', false);
+    await chrome.storage.sync.remove('copilotkitSettings');
+    apiKeyInput.value = '';
+    endpointInput.value = '';
+    renderStatus('CopilotKit settings removed.', false);
   } catch (error) {
-    console.error('[Permit AI Helper] Failed to clear API key', error);
-    renderStatus('Could not clear the key. Try again.', true);
+    console.error('[Permit AI Helper] Failed to clear CopilotKit settings', error);
+    renderStatus('Could not clear the settings. Try again.', true);
   }
 });
 


### PR DESCRIPTION
## Summary
- replace the background OpenAI chat completion call with a CopilotKit GraphQL mutation and response handling
- add Copilot Cloud public API key and optional endpoint inputs on the options page and persist them in sync storage
- refresh docs, styling, and runtime messaging to reference CopilotKit instead of OpenAI

## Testing
- not run (extension manual testing required)


------
https://chatgpt.com/codex/tasks/task_e_68dc2854d114832ca76644bd31c2ec92